### PR TITLE
Game formatter class

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -21,6 +21,21 @@ class Frame {
     this.#updateStatus();
   }
 
+  format() {
+    const symbols = this.#rolls.map((roll) => roll === 0 ? '-' : roll);
+    if (symbols.length === 0 ) {
+      return '     ';
+    } else if (symbols.length === 1 && this.#score >= 10) {
+      return '    X';
+    } else if (symbols.length === 1) {
+      return `${symbols[0]}    `;
+    } else if (symbols.length === 2 && this.#score >= 10) {
+      return `${symbols[0]} , /`;
+    } else if (symbols.length === 2) {
+      return `${symbols[0]} , ${symbols[1]}`;
+    }
+  }
+
   getScore() {
     return this.#score;
   }

--- a/lib/gameFormatter.js
+++ b/lib/gameFormatter.js
@@ -1,0 +1,48 @@
+const sprintf = require('sprintf-js').sprintf;
+
+class GameFormatter {
+  constructor(game) {
+    this.game = game;
+  }
+
+  getScorecard() {
+    const scorecardArray = []
+    this.#addHeader(scorecardArray);
+        
+    const frames = this.game.getFrames();
+    frames.forEach((frame, index) => {
+      this.#addFrame(scorecardArray, frame, index);
+    });
+    
+    this.#addFooter(scorecardArray);
+    return scorecardArray.join('\n');
+  }
+
+  #addHeader(scorecardArray) {
+    scorecardArray.push('| FRAME | ROLLS | SCORE |');
+    scorecardArray.push('| ===== | ===== | ===== |');
+  }
+
+  #addFrame(scorecardArray, frame, index) {
+    const indexString = sprintf(' %1$2d. ', index + 1);
+    const rollString = frame.format();
+    let scoreString = '     ';
+    if (frame.getStatus() === 'completed') {
+      scoreString = sprintf(' %1$3d ', this.#getScoreUntil(index));
+    }
+    scorecardArray.push(`| ${indexString} | ${rollString} | ${scoreString} |`);
+  }
+
+  #addFooter(scorecardArray) {
+    const totalScore = sprintf(' %1$3s ', this.#getScoreUntil(10));
+    scorecardArray.push(`|       | TOTAL | ${totalScore} |`);
+  }
+
+  #getScoreUntil(index) {
+    const frames = this.game.getFrames();
+    return frames.slice(0, index + 1)
+      .reduce((sum, frame) => sum + frame.getScore(), 0);
+  }
+}
+
+module.exports = GameFormatter;

--- a/lib/gameFormatter.js
+++ b/lib/gameFormatter.js
@@ -20,7 +20,7 @@ class GameFormatter {
 
   #addHeader(scorecardArray) {
     scorecardArray.push('| FRAME | ROLLS | SCORE |');
-    scorecardArray.push('| ===== | ===== | ===== |');
+    scorecardArray.push('| ----- | ----- | ----- |');
   }
 
   #addFrame(scorecardArray, frame, index) {

--- a/lib/gameFormatter.js
+++ b/lib/gameFormatter.js
@@ -41,7 +41,9 @@ class GameFormatter {
   #getScoreUntil(index) {
     const frames = this.game.getFrames();
     return frames.slice(0, index + 1)
-      .reduce((sum, frame) => sum + frame.getScore(), 0);
+      .reduce((sum, frame) => 
+        frame.getStatus() === 'completed' ? sum + frame.getScore() : sum
+      , 0);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "jest": "^29.3.1"
+        "jest": "^29.3.1",
+        "sprintf-js": "^1.1.2"
       },
       "devDependencies": {
         "eslint": "^8.29.0"
@@ -1224,6 +1225,11 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/argparse/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/babel-jest": {
       "version": "29.3.1",
@@ -3591,9 +3597,9 @@
       }
     },
     "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -4857,6 +4863,13 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+        }
       }
     },
     "babel-jest": {
@@ -6558,9 +6571,9 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/ThomasSel/bowling-challenge#readme",
   "dependencies": {
-    "jest": "^29.3.1"
+    "jest": "^29.3.1",
+    "sprintf-js": "^1.1.2"
   },
   "devDependencies": {
     "eslint": "^8.29.0"

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -109,4 +109,37 @@ describe(Frame, () => {
       expect(() => frame.addRoll()).toThrow('Cannot add rolls to this frame');
     });
   });
+
+  describe('Format method', () => {
+    it('initialized frame', () => {
+      const frame = new Frame();
+      expect(frame.format()).toEqual("     ");
+    });
+
+    it('one roll', () => {
+      const frame = new Frame();
+      frame.addRoll(5);
+      expect(frame.format()).toEqual('5    ');
+    });
+
+    it('two rolls', () => {
+      const frame = new Frame();
+      frame.addRoll(5);
+      frame.addRoll(4);
+      expect(frame.format()).toEqual('5 , 4');
+    });
+
+    it('strike', () => {
+      const frame = new Frame();
+      frame.addRoll(10);
+      expect(frame.format()).toEqual('    X');
+    });
+
+    it('spare', () => {
+      const frame = new Frame();
+      frame.addRoll(7);
+      frame.addRoll(3);
+      expect(frame.format()).toEqual('7 , /');
+    });
+  });
 });

--- a/test/gameFomatter_integration.test.js
+++ b/test/gameFomatter_integration.test.js
@@ -41,5 +41,17 @@ describe('GameFormatter integration', () => {
       expect(scorecard).toContain('|   4.  |       |       |');
       expect(scorecard).toContain('|       | TOTAL |   16  |');
     });
+
+    it('gutter game', () => {
+      for (let i = 0; i < 20; i++) {
+        game.addRoll(0);
+      }
+
+      const scorecard = gameFormatter.getScorecard();
+      expect(scorecard).toContain('|   1.  | - , - |    0  |');
+      expect(scorecard).toContain('|   2.  | - , - |    0  |');
+      expect(scorecard).toContain('|  10.  | - , - |    0  |');
+      expect(scorecard).toContain('|       | TOTAL |    0  |');
+    });
   });
 });

--- a/test/gameFomatter_integration.test.js
+++ b/test/gameFomatter_integration.test.js
@@ -29,6 +29,25 @@ describe('GameFormatter integration', () => {
       expect(scorecard).toContain('|       | TOTAL |    9  |');
     });
 
+    it('one spare', () => {
+      game.addRoll(7);
+      game.addRoll(3);
+
+      const scorecard = gameFormatter.getScorecard();
+      expect(scorecard).toContain('|   1.  | 7 , / |       |');
+      expect(scorecard).toContain('|   2.  |       |       |');
+      expect(scorecard).toContain('|       | TOTAL |    0  |');
+    });
+
+    it('one strike', () => {
+      game.addRoll(10);
+      
+      const scorecard = gameFormatter.getScorecard();
+      expect(scorecard).toContain('|   1.  |     X |       |');
+      expect(scorecard).toContain('|   2.  |       |       |');
+      expect(scorecard).toContain('|       | TOTAL |    0  |');
+    });
+
     it('2 and a half frames (ONE CALL)', () => {
       for (let i = 0; i < 5; i++) {
         game.addRoll(4);

--- a/test/gameFomatter_integration.test.js
+++ b/test/gameFomatter_integration.test.js
@@ -12,12 +12,34 @@ describe('GameFormatter integration', () => {
 
   describe('Initialized game', () => {
     it('returns an empty scorecard', () => {
-      scorecard = gameFormatter.getScorecard();
+      const scorecard = gameFormatter.getScorecard();
       expect(scorecard).toContain('| FRAME | ROLLS | SCORE |');
       expect(scorecard).toContain('|   1.  |       |       |');
       expect(scorecard).toContain('|  10.  |       |       |');
       expect(scorecard).toContain('|       | TOTAL |    0  |');
     });
-  });
 
+    it('one frame', () => {
+      game.addRoll(7);
+      game.addRoll(2);
+      
+      const scorecard = gameFormatter.getScorecard();
+      expect(scorecard).toContain('|   1.  | 7 , 2 |    9  |');
+      expect(scorecard).toContain('|   2.  |       |       |');
+      expect(scorecard).toContain('|       | TOTAL |    9  |');
+    });
+
+    it('2 and a half frames (ONE CALL)', () => {
+      for (let i = 0; i < 5; i++) {
+        game.addRoll(4);
+      }
+
+      const scorecard = gameFormatter.getScorecard();
+      expect(scorecard).toContain('|   1.  | 4 , 4 |    8  |');
+      expect(scorecard).toContain('|   2.  | 4 , 4 |   16  |');
+      expect(scorecard).toContain('|   3.  | 4     |       |');
+      expect(scorecard).toContain('|   4.  |       |       |');
+      expect(scorecard).toContain('|       | TOTAL |   16  |');
+    });
+  });
 });

--- a/test/gameFomatter_integration.test.js
+++ b/test/gameFomatter_integration.test.js
@@ -1,0 +1,23 @@
+const GameFormatter = require('../lib/gameFormatter');
+const Game = require('../lib/game');
+
+describe('GameFormatter integration', () => {
+  let game;
+  let gameFormatter;
+
+  beforeEach(() => {
+    game = new Game();
+    gameFormatter = new GameFormatter(game);
+  });
+
+  describe('Initialized game', () => {
+    it('returns an empty scorecard', () => {
+      scorecard = gameFormatter.getScorecard();
+      expect(scorecard).toContain('| FRAME | ROLLS | SCORE |');
+      expect(scorecard).toContain('|   1.  |       |       |');
+      expect(scorecard).toContain('|  10.  |       |       |');
+      expect(scorecard).toContain('|       | TOTAL |    0  |');
+    });
+  });
+
+});

--- a/test/gameFormatter.test.js
+++ b/test/gameFormatter.test.js
@@ -1,0 +1,42 @@
+const GameFormatter = require('../lib/gameFormatter');
+const Game = require('../lib/game');
+
+jest.mock('../lib/game');
+
+describe(GameFormatter, () => {
+  it('example full game without a bonus final roll', () => {
+    Game.mockImplementation(() => {
+      return {
+        getFrames: () => [
+          { getScore: () => 9, getRolls: () => [4,5], getStatus: () => 'completed', format: () => '4 , 5' },
+          { getScore: () => 8, getRolls: () => [0,8], getStatus: () => 'completed', format: () => '- , 8' },
+          { getScore: () => 11, getRolls: () => [2,8], getStatus: () => 'completed', format: () => '2 , /' },
+          { getScore: () => 1, getRolls: () => [1,0], getStatus: () => 'completed', format: () => '1 , -' },
+          { getScore: () => 15, getRolls: () => [10], getStatus: () => 'completed', format: () => '    X' },
+          { getScore: () => 5, getRolls: () => [4,1], getStatus: () => 'completed', format: () => '4 , 1' },
+          { getScore: () => 0, getRolls: () => [0,0], getStatus: () => 'completed', format: () => '- , -' },
+          { getScore: () => 8, getRolls: () => [7,1], getStatus: () => 'completed', format: () => '7 , 1' },
+          { getScore: () => 9, getRolls: () => [9,0], getStatus: () => 'completed', format: () => '9 , -' },
+          { getScore: () => 9, getRolls: () => [8,1], getStatus: () => 'completed', format: () => '8 , 1' }
+        ]
+      }
+    });
+
+    const mockGame = new Game();
+    const gameFormatter = new GameFormatter(mockGame);
+
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('| FRAME | ROLLS | SCORE |');
+    expect(scorecard).toContain('|   1.  | 4 , 5 |    9  |');
+    expect(scorecard).toContain('|   2.  | - , 8 |   17  |');
+    expect(scorecard).toContain('|   3.  | 2 , / |   28  |');
+    expect(scorecard).toContain('|   4.  | 1 , - |   29  |');
+    expect(scorecard).toContain('|   5.  |     X |   44  |');
+    expect(scorecard).toContain('|   6.  | 4 , 1 |   49  |');
+    expect(scorecard).toContain('|   7.  | - , - |   49  |');
+    expect(scorecard).toContain('|   8.  | 7 , 1 |   57  |');
+    expect(scorecard).toContain('|   9.  | 9 , - |   66  |');
+    expect(scorecard).toContain('|  10.  | 8 , 1 |   75  |');
+    expect(scorecard).toContain('|       | TOTAL |   75  |');
+  });
+});


### PR DESCRIPTION
Adds a `GameFormatter` class that takes a `Game` object and prints out a scorecard for said game.

The scorecard is output in a markdown table format and always shows all ten frames.
```
EXAMPLE OUTPUT:

| FRAME | ROLLS | SCORE |
| ----- | ----- | ----- |
|   1.  | 4 , 5 |    9  |
|   2.  | - , 8 |   17  |
|   3.  | 2 , / |   28  |
|   4.  | 1 , - |   29  |
|   5.  |     X |   44  |
|   6.  | 4 , 1 |   49  |
|   7.  | - , - |   49  |
|   8.  | 7 , 1 |   57  |
|   9.  | 9 , - |   66  |
|  10.  | 8 , 1 |   75  |
| ===== | ===== | ===== |
|       | TOTAL |   75  |
```

This scorecard works both for partial and completed games.
In particular, the scorecard hides the score for partial games, and games with unresolved bonuses (it does so by printing out the score for frames who's `status` is `completed`)
