### PR TITLE
Bonuses

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -2,17 +2,18 @@ class Frame {
   #score;
   #rolls;
   #status;
+  #bonusesLeft;
   
   constructor() {
     this.#score = 0;
     this.#rolls = [];
     this.#status = 'active';
+    this.#bonusesLeft = 0;
   }
 
   addRoll(roll) {
+    this.#validateRoll(roll);
     if (this.#status !== 'active') throw 'Cannot add rolls to this frame';
-    if (roll < 0 || roll > 10) throw 'A roll must be between 0 and 10';
-    if (!Number.isInteger(roll)) throw 'A roll must be an integer';
     if (this.#score + roll > 10) throw 'Rolls cannot add up to more than 10';
 
     this.#score += roll;
@@ -21,6 +22,15 @@ class Frame {
     this.#updateStatus();
   }
 
+  addBonus(roll) {
+    this.#validateRoll(roll);
+    if (this.#bonusesLeft > 0) {
+      this.#score += roll;
+      this.#bonusesLeft--;
+      if (this.#bonusesLeft === 0) this.#status = 'completed';
+    }
+  }
+  
   format() {
     const symbols = this.#rolls.map((roll) => roll === 0 ? '-' : roll);
     if (symbols.length === 0 ) {
@@ -51,11 +61,18 @@ class Frame {
   #updateStatus() {
     if (this.#score === 10 && this.#rolls.length === 1) {
       this.#status = 'strike';
+      this.#bonusesLeft = 2;
     } else if (this.#score === 10 && this.#rolls.length === 2) {
       this.#status = 'spare';
+      this.#bonusesLeft = 1;
     } else if (this.#rolls.length === 2) {
       this.#status = 'completed';
     }
+  }
+
+  #validateRoll(roll) {
+    if (roll < 0 || roll > 10) throw 'A roll must be between 0 and 10';
+    if (!Number.isInteger(roll)) throw 'A roll must be an integer';
   }
 }
 

--- a/lib/game.js
+++ b/lib/game.js
@@ -4,8 +4,9 @@ class Game {
   #frames; #currentFrame;
 
   constructor() {
+    this.#currentFrame = 0;
+    
     this.#frames = [];
-    this.#currentFrame = 1;
     for (let i = 0; i < 10; i++) {
       this.#frames.push(new Frame());
     }
@@ -16,12 +17,18 @@ class Game {
   }
 
   addRoll(roll) {
-    if (this.#currentFrame > 10){
+    if (this.#currentFrame >= 10){
       throw 'The game is complete, cannot add any more rolls';
     }
 
-    const frame = this.#frames[this.#currentFrame - 1];
+    const frame = this.#frames[this.#currentFrame];
     frame.addRoll(roll);
+
+    const previousTwoFrames = this.#frames.slice(
+      Math.max(0, this.#currentFrame - 2), this.#currentFrame
+    );
+    previousTwoFrames.forEach(prevFrame => prevFrame.addBonus(roll));
+
     if (frame.getStatus() !== 'active') this.#currentFrame++;
   }
 }

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -87,17 +87,17 @@ describe(Frame, () => {
     it('throws error', () => {
       frame.addRoll(10);
       expect(frame.getStatus()).toEqual('strike');
-      expect(() => frame.addRoll()).toThrow('Cannot add rolls to this frame');
+      expect(() => frame.addRoll(0)).toThrow('Cannot add rolls to this frame');
 
       frame = new Frame();
       frame.addRoll(1);
       frame.addRoll(9);
       expect(frame.getStatus()).toEqual('spare');
-      expect(() => frame.addRoll()).toThrow('Cannot add rolls to this frame');
+      expect(() => frame.addRoll(0)).toThrow('Cannot add rolls to this frame');
     });
   });
 
-  describe('Format method', () => {
+  describe('format method', () => {
     it('initialized frame', () => {
       expect(frame.format()).toEqual("     ");
     });
@@ -122,6 +122,66 @@ describe(Frame, () => {
       frame.addRoll(7);
       frame.addRoll(3);
       expect(frame.format()).toEqual('7 , /');
+    });
+  });
+
+  describe('addBonus method', () => {
+    it("throws if roll isn't an integer between 0 and 10", () => {
+      frame.addRoll(10);
+      
+      expect(() => frame.addBonus(-1))
+        .toThrow('A roll must be between 0 and 10');
+      expect(() => frame.addBonus(15))
+        .toThrow('A roll must be between 0 and 10');
+
+      expect(() => frame.addBonus('Hello world'))
+        .toThrow('A roll must be an integer');
+      expect(() => frame.addBonus(1.5))
+        .toThrow('A roll must be an integer');
+      
+      expect(frame.getScore()).toEqual(10);
+
+      expect(() => frame.addBonus(1.0)).not.toThrow();
+    });
+
+    it("does nothing if status isn't strike or spare", () => {
+      frame.addBonus(5);
+      expect(frame.getScore()).toBe(0);
+
+      frame.addRoll(3);
+      frame.addRoll(2);
+      frame.addBonus(7);
+      expect(frame.getScore()).toBe(5)
+    });
+
+    it('adds two bonuses if we rolled a strike', () => {
+      frame.addRoll(10);
+      expect(frame.getScore()).toBe(10);
+      expect(frame.getStatus()).toEqual('strike');
+
+      frame.addBonus(5);
+      expect(frame.getScore()).toBe(15);
+
+      frame.addBonus(2);
+      expect(frame.getScore()).toBe(17);
+      expect(frame.getStatus()).toEqual('completed');
+
+      frame.addBonus(7);
+      expect(frame.getScore()).toBe(17);
+    });
+
+    it('adds one bonus if we rolled a spare', () => {
+      frame.addRoll(5);
+      frame.addRoll(5);
+      expect(frame.getScore()).toBe(10);
+      expect(frame.getStatus()).toEqual('spare');
+
+      frame.addBonus(3);
+      expect(frame.getScore()).toBe(13);
+      expect(frame.getStatus()).toEqual('completed');
+      
+      frame.addBonus(7);
+      expect(frame.getScore()).toBe(13);
     });
   });
 });

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -3,19 +3,23 @@ const Frame = require('../lib/frame');
 
 jest.mock('../lib/frame');
 
+mockFrame = (status) => {
+  Frame.mockImplementation(() => {
+    return {
+      getScore: () => 0,
+      getRolls: () => [],
+      getStatus: () => status,
+      addRoll: jest.fn(x => null),
+      addBonus: jest.fn(x => null)
+    };
+  });
+}
+
 describe(Game, () => {
   let game;
 
   beforeAll(() => {
-    Frame.mockImplementation(() => {
-      return {
-        getScore: () => 0,
-        getRolls: () => [],
-        getStatus: () => 'active',
-        addRoll: jest.fn(x => null)
-      };
-    });
-
+    mockFrame('active');
     game = new Game();
   });
 
@@ -31,5 +35,22 @@ describe(Game, () => {
   it("addFrame calls the first frame's addFrame method", () => {
     game.addRoll(5);
     expect(game.getFrames()[0].addRoll).toHaveBeenCalledTimes(1);
+  });
+
+  it('addFrame calls addBonus once on the second frame and twice on the third frame', () => {
+    mockFrame('completed');
+    game = new Game();
+
+    game.addRoll(0);
+    expect(game.getFrames()[0].addBonus).not.toHaveBeenCalled();
+
+    game.addRoll(1);
+    expect(game.getFrames()[0].addBonus).toHaveBeenCalledWith(1);
+    expect(game.getFrames()[1].addBonus).not.toHaveBeenCalled();
+
+    game.addRoll(2);
+    expect(game.getFrames()[0].addBonus).toHaveBeenCalledWith(2);
+    expect(game.getFrames()[1].addBonus).toHaveBeenCalledWith(2);
+    expect(game.getFrames()[2].addBonus).not.toHaveBeenCalled();
   });
 });

--- a/test/gameFormatter_integration.test.js
+++ b/test/gameFormatter_integration.test.js
@@ -18,59 +18,115 @@ describe('GameFormatter integration', () => {
       expect(scorecard).toContain('|  10.  |       |       |');
       expect(scorecard).toContain('|       | TOTAL |    0  |');
     });
+  });
 
-    it('one frame', () => {
-      game.addRoll(7);
-      game.addRoll(2);
-      
-      const scorecard = gameFormatter.getScorecard();
-      expect(scorecard).toContain('|   1.  | 7 , 2 |    9  |');
-      expect(scorecard).toContain('|   2.  |       |       |');
-      expect(scorecard).toContain('|       | TOTAL |    9  |');
-    });
+  it('one frame', () => {
+    game.addRoll(7);
+    game.addRoll(2);
+    
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  | 7 , 2 |    9  |');
+    expect(scorecard).toContain('|   2.  |       |       |');
+    expect(scorecard).toContain('|       | TOTAL |    9  |');
+  });
 
-    it('one spare', () => {
-      game.addRoll(7);
-      game.addRoll(3);
+  it('one spare', () => {
+    game.addRoll(7);
+    game.addRoll(3);
 
-      const scorecard = gameFormatter.getScorecard();
-      expect(scorecard).toContain('|   1.  | 7 , / |       |');
-      expect(scorecard).toContain('|   2.  |       |       |');
-      expect(scorecard).toContain('|       | TOTAL |    0  |');
-    });
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  | 7 , / |       |');
+    expect(scorecard).toContain('|   2.  |       |       |');
+    expect(scorecard).toContain('|       | TOTAL |    0  |');
+  });
 
-    it('one strike', () => {
+  it('one strike', () => {
+    game.addRoll(10);
+    
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  |     X |       |');
+    expect(scorecard).toContain('|   2.  |       |       |');
+    expect(scorecard).toContain('|       | TOTAL |    0  |');
+  });
+
+  it('2 and a half frames (all rolls of 4)', () => {
+    for (let i = 0; i < 5; i++) {
+      game.addRoll(4);
+    }
+
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  | 4 , 4 |    8  |');
+    expect(scorecard).toContain('|   2.  | 4 , 4 |   16  |');
+    expect(scorecard).toContain('|   3.  | 4     |       |');
+    expect(scorecard).toContain('|   4.  |       |       |');
+    expect(scorecard).toContain('|       | TOTAL |   16  |');
+  });
+
+  it('two strikes and a roll', () => {
+    game.addRoll(10);
+    game.addRoll(10);
+    game.addRoll(4);
+
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  |     X |   24  |');
+    expect(scorecard).toContain('|   2.  |     X |       |');
+    expect(scorecard).toContain('|   3.  | 4     |       |');
+    expect(scorecard).toContain('|   4.  |       |       |');
+    expect(scorecard).toContain('|       | TOTAL |   24  |');
+  });
+
+  it('two [7, 3] spares and a roll', () => {
+    game.addRoll(7); game.addRoll(3);
+    game.addRoll(7); game.addRoll(3);
+    game.addRoll(4);
+
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  | 7 , / |   17  |');
+    expect(scorecard).toContain('|   2.  | 7 , / |   31  |');
+    expect(scorecard).toContain('|   3.  | 4     |       |');
+    expect(scorecard).toContain('|   4.  |       |       |');
+    expect(scorecard).toContain('|       | TOTAL |   31  |');
+  });
+
+  it('10 strikes (without frame 10)', () => {
+    for (let i = 0; i < 10; i++) {
       game.addRoll(10);
-      
-      const scorecard = gameFormatter.getScorecard();
-      expect(scorecard).toContain('|   1.  |     X |       |');
-      expect(scorecard).toContain('|   2.  |       |       |');
-      expect(scorecard).toContain('|       | TOTAL |    0  |');
-    });
+    }
 
-    it('2 and a half frames (ONE CALL)', () => {
-      for (let i = 0; i < 5; i++) {
-        game.addRoll(4);
-      }
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  |     X |   30  |');
+    expect(scorecard).toContain('|   2.  |     X |   60  |');
+    expect(scorecard).toContain('|   8.  |     X |  240  |');
+    expect(scorecard).toContain('|   9.  |     X |       |');
+    expect(scorecard).toContain('|  10.  |     X |       |');
+    expect(scorecard).toContain('|       | TOTAL |  240  |');
+  });
 
-      const scorecard = gameFormatter.getScorecard();
-      expect(scorecard).toContain('|   1.  | 4 , 4 |    8  |');
-      expect(scorecard).toContain('|   2.  | 4 , 4 |   16  |');
-      expect(scorecard).toContain('|   3.  | 4     |       |');
-      expect(scorecard).toContain('|   4.  |       |       |');
-      expect(scorecard).toContain('|       | TOTAL |   16  |');
-    });
+  it('9 [9, 1] spares and two gutter balls', () => {
+    for (let i = 0; i < 9; i++) {
+      game.addRoll(9);
+      game.addRoll(1);
+    }
+    game.addRoll(0); game.addRoll(0);
 
-    it('gutter game', () => {
-      for (let i = 0; i < 20; i++) {
-        game.addRoll(0);
-      }
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  | 9 , / |   19  |');
+    expect(scorecard).toContain('|   2.  | 9 , / |   38  |');
+    expect(scorecard).toContain('|   8.  | 9 , / |  152  |');
+    expect(scorecard).toContain('|   9.  | 9 , / |  162  |');
+    expect(scorecard).toContain('|  10.  | - , - |  162  |');
+    expect(scorecard).toContain('|       | TOTAL |  162  |');
+  });
 
-      const scorecard = gameFormatter.getScorecard();
-      expect(scorecard).toContain('|   1.  | - , - |    0  |');
-      expect(scorecard).toContain('|   2.  | - , - |    0  |');
-      expect(scorecard).toContain('|  10.  | - , - |    0  |');
-      expect(scorecard).toContain('|       | TOTAL |    0  |');
-    });
+  it('gutter game', () => {
+    for (let i = 0; i < 20; i++) {
+      game.addRoll(0);
+    }
+
+    const scorecard = gameFormatter.getScorecard();
+    expect(scorecard).toContain('|   1.  | - , - |    0  |');
+    expect(scorecard).toContain('|   2.  | - , - |    0  |');
+    expect(scorecard).toContain('|  10.  | - , - |    0  |');
+    expect(scorecard).toContain('|       | TOTAL |    0  |');
   });
 });

--- a/test/game_integration.test.js
+++ b/test/game_integration.test.js
@@ -1,4 +1,3 @@
-const Frame = require('../lib/frame');
 const Game = require('../lib/game');
 
 describe('Game integration', () => {
@@ -134,7 +133,7 @@ describe('Game integration', () => {
       game.addRoll(6);
       game.addRoll(4);
 
-      frames = game.getFrames();
+      const frames = game.getFrames();
       expect(frames[0].getRolls()).toEqual([10]);
       expect(frames[0].getScore()).toEqual(16);
       expect(frames[0].getStatus()).toEqual('completed');

--- a/test/game_integration.test.js
+++ b/test/game_integration.test.js
@@ -61,18 +61,6 @@ describe('Game integration', () => {
       expect(frames[2].getRolls()).toEqual([4]);
       expect(frames[2].getStatus()).toEqual('active');
     });
-
-    it('two strikes and a roll', () => {
-      game.addRoll(10);
-      game.addRoll(10);
-      game.addRoll(4);
-
-      const frames = game.getFrames();
-      expect(frames[0].getStatus()).toEqual('strike');
-      expect(frames[1].getStatus()).toEqual('strike');
-      expect(frames[2].getRolls()).toEqual([4]);
-      expect(frames[2].getStatus()).toEqual('active');
-    });
   });
 
   describe('Full game', () => {
@@ -96,6 +84,39 @@ describe('Game integration', () => {
       expect(frames.every(frame => frame.getStatus() === 'completed')).toBe(true);
     });
 
+    it('10 strikes (without frame 10)', () => {
+      for (let i = 0; i < 10; i++) {
+        game.addRoll(10);
+      }
+
+      const frames = game.getFrames();
+      for (let i = 0; i < 8; i++) {
+        expect(frames[i].getScore()).toBe(30);
+        expect(frames[i].getStatus()).toBe('completed')
+      }
+
+      expect(frames[8].getScore()).toBe(20);
+      expect(frames[8].getStatus()).toBe('strike')
+
+      expect(frames[9].getScore()).toBe(10);
+      expect(frames[9].getStatus()).toBe('strike')
+    });
+
+    it('10 [9, 1] spares (without frame 10)', () => {
+      for (let i = 0; i < 10; i++) {
+        game.addRoll(9);
+        game.addRoll(1);
+      }
+
+      const frames = game.getFrames();
+      for (let i = 0; i < 9; i++) {
+        expect(frames[i].getScore()).toBe(19);
+        expect(frames[i].getStatus()).toBe('completed')
+      }
+
+      expect(frames[9].getScore()).toBe(10);
+    });
+
     it('throws error when trying to add a new roll', () => {
       for (let i = 0; i < 20; i++) {
         game.addRoll(4);
@@ -103,6 +124,53 @@ describe('Game integration', () => {
 
       const errorMessage = 'The game is complete, cannot add any more rolls';
       expect(() => game.addRoll(4)).toThrow(errorMessage);
+    });
+  });
+
+  describe('Strike bonuses', () => {
+    it('adds two bonuses from the next frame', () => {
+      game.addRoll(10);
+      game.addRoll(0);
+      game.addRoll(6);
+      game.addRoll(4);
+
+      frames = game.getFrames();
+      expect(frames[0].getRolls()).toEqual([10]);
+      expect(frames[0].getScore()).toEqual(16);
+      expect(frames[0].getStatus()).toEqual('completed');
+    });
+
+    it('two strikes and a roll', () => {
+      game.addRoll(10);
+      game.addRoll(10);
+      game.addRoll(4);
+
+      const frames = game.getFrames();
+      expect(frames[0].getStatus()).toEqual('completed');
+      expect(frames[0].getRolls()).toEqual([10]);
+      expect(frames[0].getScore()).toEqual(24);
+
+      expect(frames[1].getStatus()).toEqual('strike');
+      expect(frames[1].getRolls()).toEqual([10]);
+      expect(frames[1].getScore()).toEqual(14);
+
+      expect(frames[2].getRolls()).toEqual([4]);
+      expect(frames[2].getStatus()).toEqual('active');
+    });
+  });
+
+  describe('Spare bonuses', () => {
+    it('adds one bonus from the next frame', () => {
+      game.addRoll(9);
+      game.addRoll(1);
+
+      game.addRoll(6);
+      expect(game.getFrames()[0].getRolls()).toEqual([9, 1]);
+      expect(game.getFrames()[0].getScore()).toEqual(16);
+      expect(game.getFrames()[0].getStatus()).toEqual('completed');
+
+      game.addRoll(4);
+      expect(game.getFrames()[0].getScore()).toEqual(16);
     });
   });
 });


### PR DESCRIPTION
### A `Frame` level implementation of strike / spare bonuses.

We implemented a `addBonus` method to the `Frame` class which adds a bonus to the frame's score if the status is `'strike'` or `'spare'`. We then update the frame's status at the end of each call. If the frame's status is not `'strike'` or `'spare'` then we simply do nothing (no error is thrown).

We then add calls to `addBonus` in `Game.addRoll` to the two frames before the current one, allowing for strike chaining in particular.