### PR TITLE
Refactor private variables

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -1,72 +1,56 @@
 class Frame {
-  #score;
-  #rolls;
-  #status;
-  #bonusesLeft;
   
   constructor() {
-    this.#score = 0;
-    this.#rolls = [];
-    this.#status = 'active';
-    this.#bonusesLeft = 0;
+    this.score = 0;
+    this.rolls = [];
+    this.status = 'active';
+    this.bonusesLeft = 0;
   }
 
   addRoll(roll) {
     this.#validateRoll(roll);
-    if (this.#status !== 'active') throw 'Cannot add rolls to this frame';
-    if (this.#score + roll > 10) throw 'Rolls cannot add up to more than 10';
+    if (this.status !== 'active') throw 'Cannot add rolls to this frame';
+    if (this.score + roll > 10) throw 'Rolls cannot add up to more than 10';
 
-    this.#score += roll;
-    this.#rolls.push(roll);
+    this.score += roll;
+    this.rolls.push(roll);
     
     this.#updateStatus();
   }
 
   addBonus(roll) {
     this.#validateRoll(roll);
-    if (this.#bonusesLeft > 0) {
-      this.#score += roll;
-      this.#bonusesLeft--;
-      if (this.#bonusesLeft === 0) this.#status = 'completed';
+    if (this.bonusesLeft > 0) {
+      this.score += roll;
+      this.bonusesLeft--;
+      if (this.bonusesLeft === 0) this.status = 'completed';
     }
   }
   
   format() {
-    const symbols = this.#rolls.map((roll) => roll === 0 ? '-' : roll);
+    const symbols = this.rolls.map((roll) => roll === 0 ? '-' : roll);
     if (symbols.length === 0 ) {
       return '     ';
-    } else if (symbols.length === 1 && this.#score >= 10) {
+    } else if (symbols.length === 1 && this.score >= 10) {
       return '    X';
     } else if (symbols.length === 1) {
       return `${symbols[0]}    `;
-    } else if (symbols.length === 2 && this.#score >= 10) {
+    } else if (symbols.length === 2 && this.score >= 10) {
       return `${symbols[0]} , /`;
     } else if (symbols.length === 2) {
       return `${symbols[0]} , ${symbols[1]}`;
     }
   }
 
-  getScore() {
-    return this.#score;
-  }
-
-  getRolls() {
-    return this.#rolls;
-  }
-
-  getStatus() {
-    return this.#status;
-  }
-
   #updateStatus() {
-    if (this.#score === 10 && this.#rolls.length === 1) {
-      this.#status = 'strike';
-      this.#bonusesLeft = 2;
-    } else if (this.#score === 10 && this.#rolls.length === 2) {
-      this.#status = 'spare';
-      this.#bonusesLeft = 1;
-    } else if (this.#rolls.length === 2) {
-      this.#status = 'completed';
+    if (this.score === 10 && this.rolls.length === 1) {
+      this.status = 'strike';
+      this.bonusesLeft = 2;
+    } else if (this.score === 10 && this.rolls.length === 2) {
+      this.status = 'spare';
+      this.bonusesLeft = 1;
+    } else if (this.rolls.length === 2) {
+      this.status = 'completed';
     }
   }
 

--- a/lib/game.js
+++ b/lib/game.js
@@ -1,35 +1,29 @@
 const Frame = require('./frame');
 
 class Game {
-  #frames; #currentFrame;
-
   constructor() {
-    this.#currentFrame = 0;
+    this.currentFrame = 0;
     
-    this.#frames = [];
+    this.frames = [];
     for (let i = 0; i < 10; i++) {
-      this.#frames.push(new Frame());
+      this.frames.push(new Frame());
     }
-  }
-
-  getFrames() {
-    return this.#frames;
   }
 
   addRoll(roll) {
-    if (this.#currentFrame >= 10){
+    if (this.currentFrame >= 10){
       throw 'The game is complete, cannot add any more rolls';
     }
 
-    const frame = this.#frames[this.#currentFrame];
+    const frame = this.frames[this.currentFrame];
     frame.addRoll(roll);
 
-    const previousTwoFrames = this.#frames.slice(
-      Math.max(0, this.#currentFrame - 2), this.#currentFrame
+    const previousTwoFrames = this.frames.slice(
+      Math.max(0, this.currentFrame - 2), this.currentFrame
     );
     previousTwoFrames.forEach(prevFrame => prevFrame.addBonus(roll));
 
-    if (frame.getStatus() !== 'active') this.#currentFrame++;
+    if (frame.status !== 'active') this.currentFrame++;
   }
 }
 

--- a/lib/gameFormatter.js
+++ b/lib/gameFormatter.js
@@ -9,9 +9,9 @@ class GameFormatter {
     const scorecardArray = []
     this.#addHeader(scorecardArray);
         
-    const frames = this.game.getFrames();
+    const frames = this.game.frames;
     frames.forEach((frame, index) => {
-      this.#addFrame(scorecardArray, frame, index);
+      this.#addFrameString(scorecardArray, frame, index);
     });
     
     this.#addFooter(scorecardArray);
@@ -23,11 +23,11 @@ class GameFormatter {
     scorecardArray.push('| ----- | ----- | ----- |');
   }
 
-  #addFrame(scorecardArray, frame, index) {
+  #addFrameString(scorecardArray, frame, index) {
     const indexString = sprintf(' %1$2d. ', index + 1);
     const rollString = frame.format();
     let scoreString = '     ';
-    if (frame.getStatus() === 'completed') {
+    if (frame.status === 'completed') {
       scoreString = sprintf(' %1$3d ', this.#getScoreUntil(index));
     }
     scorecardArray.push(`| ${indexString} | ${rollString} | ${scoreString} |`);
@@ -39,10 +39,10 @@ class GameFormatter {
   }
 
   #getScoreUntil(index) {
-    const frames = this.game.getFrames();
+    const frames = this.game.frames;
     return frames.slice(0, index + 1)
       .reduce((sum, frame) => 
-        frame.getStatus() === 'completed' ? sum + frame.getScore() : sum
+        frame.status === 'completed' ? sum + frame.score : sum
       , 0);
   }
 }

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -9,32 +9,32 @@ describe(Frame, () => {
 
   describe('Initialized frame', () => {
     it('has a score of 0, an empty roll array and an active status', () => {
-      expect(frame.getScore()).toEqual(0);
-      expect(frame.getRolls()).toEqual([]);
-      expect(frame.getStatus()).toEqual('active');
+      expect(frame.score).toEqual(0);
+      expect(frame.rolls).toEqual([]);
+      expect(frame.status).toEqual('active');
     });
   });
   
   describe('One roll', () => {
     it('adds a roll of 5', () => {
       frame.addRoll(5);
-      expect(frame.getScore()).toEqual(5);
-      expect(frame.getRolls()).toEqual([5]);
-      expect(frame.getStatus()).toEqual('active');
+      expect(frame.score).toEqual(5);
+      expect(frame.rolls).toEqual([5]);
+      expect(frame.status).toEqual('active');
     });
 
     it('detects a strike', () => {
       frame.addRoll(10);
-      expect(frame.getScore()).toEqual(10);
-      expect(frame.getRolls()).toEqual([10]);
-      expect(frame.getStatus()).toEqual('strike');
+      expect(frame.score).toEqual(10);
+      expect(frame.rolls).toEqual([10]);
+      expect(frame.status).toEqual('strike');
     });
 
     it('throws error when adding a roll not between 0 and 10', () => {
       expect(() => frame.addRoll(-1)).toThrow('A roll must be between 0 and 10');
       expect(() => frame.addRoll(15)).toThrow('A roll must be between 0 and 10');
 
-      expect(frame.getRolls()).toEqual([]);
+      expect(frame.rolls).toEqual([]);
     });
 
     it("throws error if the roll isn't an integer", () => {
@@ -42,11 +42,11 @@ describe(Frame, () => {
         .toThrow('A roll must be an integer');
       expect(() => frame.addRoll(1.5))
         .toThrow('A roll must be an integer');
-      expect(frame.getRolls()).toEqual([]);
+      expect(frame.rolls).toEqual([]);
 
       expect(() => frame.addRoll(1.0)).not.toThrow();
-      expect(frame.getRolls()).toStrictEqual([1])
-      expect(frame.getScore()).toBe(1)
+      expect(frame.rolls).toStrictEqual([1])
+      expect(frame.score).toBe(1)
     });
   });
 
@@ -54,17 +54,17 @@ describe(Frame, () => {
     it('adds a roll of 5 and a roll of 4', () => {
       frame.addRoll(5);
       frame.addRoll(4);
-      expect(frame.getRolls()).toEqual([5,4]);
-      expect(frame.getScore()).toEqual(9);
-      expect(frame.getStatus()).toEqual('completed');
+      expect(frame.rolls).toEqual([5,4]);
+      expect(frame.score).toEqual(9);
+      expect(frame.status).toEqual('completed');
     });
     
     it('detects a spare', () => {
       frame.addRoll(7);
       frame.addRoll(3);
-      expect(frame.getRolls()).toEqual([7,3]);
-      expect(frame.getScore()).toEqual(10);
-      expect(frame.getStatus()).toEqual('spare');
+      expect(frame.rolls).toEqual([7,3]);
+      expect(frame.score).toEqual(10);
+      expect(frame.status).toEqual('spare');
     });
     
     it('throws error if rolls add up to more than 10', () => {
@@ -86,13 +86,13 @@ describe(Frame, () => {
   describe("Add roll when status isn't active", () => {
     it('throws error', () => {
       frame.addRoll(10);
-      expect(frame.getStatus()).toEqual('strike');
+      expect(frame.status).toEqual('strike');
       expect(() => frame.addRoll(0)).toThrow('Cannot add rolls to this frame');
 
       frame = new Frame();
       frame.addRoll(1);
       frame.addRoll(9);
-      expect(frame.getStatus()).toEqual('spare');
+      expect(frame.status).toEqual('spare');
       expect(() => frame.addRoll(0)).toThrow('Cannot add rolls to this frame');
     });
   });
@@ -139,49 +139,49 @@ describe(Frame, () => {
       expect(() => frame.addBonus(1.5))
         .toThrow('A roll must be an integer');
       
-      expect(frame.getScore()).toEqual(10);
+      expect(frame.score).toEqual(10);
 
       expect(() => frame.addBonus(1.0)).not.toThrow();
     });
 
     it("does nothing if status isn't strike or spare", () => {
       frame.addBonus(5);
-      expect(frame.getScore()).toBe(0);
+      expect(frame.score).toBe(0);
 
       frame.addRoll(3);
       frame.addRoll(2);
       frame.addBonus(7);
-      expect(frame.getScore()).toBe(5)
+      expect(frame.score).toBe(5)
     });
 
     it('adds two bonuses if we rolled a strike', () => {
       frame.addRoll(10);
-      expect(frame.getScore()).toBe(10);
-      expect(frame.getStatus()).toEqual('strike');
+      expect(frame.score).toBe(10);
+      expect(frame.status).toEqual('strike');
 
       frame.addBonus(5);
-      expect(frame.getScore()).toBe(15);
+      expect(frame.score).toBe(15);
 
       frame.addBonus(2);
-      expect(frame.getScore()).toBe(17);
-      expect(frame.getStatus()).toEqual('completed');
+      expect(frame.score).toBe(17);
+      expect(frame.status).toEqual('completed');
 
       frame.addBonus(7);
-      expect(frame.getScore()).toBe(17);
+      expect(frame.score).toBe(17);
     });
 
     it('adds one bonus if we rolled a spare', () => {
       frame.addRoll(5);
       frame.addRoll(5);
-      expect(frame.getScore()).toBe(10);
-      expect(frame.getStatus()).toEqual('spare');
+      expect(frame.score).toBe(10);
+      expect(frame.status).toEqual('spare');
 
       frame.addBonus(3);
-      expect(frame.getScore()).toBe(13);
-      expect(frame.getStatus()).toEqual('completed');
+      expect(frame.score).toBe(13);
+      expect(frame.status).toEqual('completed');
       
       frame.addBonus(7);
-      expect(frame.getScore()).toBe(13);
+      expect(frame.score).toBe(13);
     });
   });
 });

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -3,13 +3,15 @@ const Frame = require('../lib/frame');
 
 jest.mock('../lib/frame');
 
-mockFrame = (status) => {
+const mockFrame = (status) => {
   Frame.mockImplementation(() => {
     return {
-      getScore: () => 0,
-      getRolls: () => [],
-      getStatus: () => status,
+      score: 0,
+      rolls: [],
+      status: status,
+      // eslint-disable-next-line no-unused-vars
       addRoll: jest.fn(x => null),
+      // eslint-disable-next-line no-unused-vars
       addBonus: jest.fn(x => null)
     };
   });
@@ -26,15 +28,15 @@ describe(Game, () => {
   it('initialized game', () => {
     expect(Frame).toHaveBeenCalledTimes(10);
 
-    const frames = game.getFrames();
+    const frames = game.frames;
     expect(frames.length).toEqual(10);
-    expect(frames.every((frame) => frame.getRolls().length === 0)).toBe(true);
-    expect(frames.every((frame) => frame.getStatus() === 'active')).toBe(true);
+    expect(frames.every((frame) => frame.rolls.length === 0)).toBe(true);
+    expect(frames.every((frame) => frame.status === 'active')).toBe(true);
   });
 
   it("addFrame calls the first frame's addFrame method", () => {
     game.addRoll(5);
-    expect(game.getFrames()[0].addRoll).toHaveBeenCalledTimes(1);
+    expect(game.frames[0].addRoll).toHaveBeenCalledTimes(1);
   });
 
   it('addFrame calls addBonus once on the second frame and twice on the third frame', () => {
@@ -42,15 +44,15 @@ describe(Game, () => {
     game = new Game();
 
     game.addRoll(0);
-    expect(game.getFrames()[0].addBonus).not.toHaveBeenCalled();
+    expect(game.frames[0].addBonus).not.toHaveBeenCalled();
 
     game.addRoll(1);
-    expect(game.getFrames()[0].addBonus).toHaveBeenCalledWith(1);
-    expect(game.getFrames()[1].addBonus).not.toHaveBeenCalled();
+    expect(game.frames[0].addBonus).toHaveBeenCalledWith(1);
+    expect(game.frames[1].addBonus).not.toHaveBeenCalled();
 
     game.addRoll(2);
-    expect(game.getFrames()[0].addBonus).toHaveBeenCalledWith(2);
-    expect(game.getFrames()[1].addBonus).toHaveBeenCalledWith(2);
-    expect(game.getFrames()[2].addBonus).not.toHaveBeenCalled();
+    expect(game.frames[0].addBonus).toHaveBeenCalledWith(2);
+    expect(game.frames[1].addBonus).toHaveBeenCalledWith(2);
+    expect(game.frames[2].addBonus).not.toHaveBeenCalled();
   });
 });

--- a/test/gameFormatter.test.js
+++ b/test/gameFormatter.test.js
@@ -7,17 +7,17 @@ describe(GameFormatter, () => {
   it('example full game without a bonus final roll', () => {
     Game.mockImplementation(() => {
       return {
-        getFrames: () => [
-          { getScore: () => 9, getRolls: () => [4,5], getStatus: () => 'completed', format: () => '4 , 5' },
-          { getScore: () => 8, getRolls: () => [0,8], getStatus: () => 'completed', format: () => '- , 8' },
-          { getScore: () => 11, getRolls: () => [2,8], getStatus: () => 'completed', format: () => '2 , /' },
-          { getScore: () => 1, getRolls: () => [1,0], getStatus: () => 'completed', format: () => '1 , -' },
-          { getScore: () => 15, getRolls: () => [10], getStatus: () => 'completed', format: () => '    X' },
-          { getScore: () => 5, getRolls: () => [4,1], getStatus: () => 'completed', format: () => '4 , 1' },
-          { getScore: () => 0, getRolls: () => [0,0], getStatus: () => 'completed', format: () => '- , -' },
-          { getScore: () => 8, getRolls: () => [7,1], getStatus: () => 'completed', format: () => '7 , 1' },
-          { getScore: () => 9, getRolls: () => [9,0], getStatus: () => 'completed', format: () => '9 , -' },
-          { getScore: () => 9, getRolls: () => [8,1], getStatus: () => 'completed', format: () => '8 , 1' }
+        frames: [
+          { score: 9, rolls: [4,5], status: 'completed', format: () => '4 , 5' },
+          { score: 8, rolls: [0,8], status: 'completed', format: () => '- , 8' },
+          { score: 11, rolls: [2,8], status: 'completed', format: () => '2 , /' },
+          { score: 1, rolls: [1,0], status: 'completed', format: () => '1 , -' },
+          { score: 15, rolls: [10], status: 'completed', format: () => '    X' },
+          { score: 5, rolls: [4,1], status: 'completed', format: () => '4 , 1' },
+          { score: 0, rolls: [0,0], status: 'completed', format: () => '- , -' },
+          { score: 8, rolls: [7,1], status: 'completed', format: () => '7 , 1' },
+          { score: 9, rolls: [9,0], status: 'completed', format: () => '9 , -' },
+          { score: 9, rolls: [8,1], status: 'completed', format: () => '8 , 1' }
         ]
       }
     });

--- a/test/game_integration.test.js
+++ b/test/game_integration.test.js
@@ -8,10 +8,10 @@ describe('Game integration', () => {
   });
 
   it('initialized game', () => {
-    const frames = game.getFrames();
+    const frames = game.frames;
     expect(frames.length).toEqual(10);
-    expect(frames.every((frame) => frame.getRolls().length === 0)).toBe(true);
-    expect(frames.every((frame) => frame.getStatus() === 'active')).toBe(true);
+    expect(frames.every((frame) => frame.rolls.length === 0)).toBe(true);
+    expect(frames.every((frame) => frame.status === 'active')).toBe(true);
   });
 
   describe('Adding one frame', () => {
@@ -19,32 +19,32 @@ describe('Game integration', () => {
       game.addRoll(5);
       game.addRoll(1);
       
-      const frames = game.getFrames();
-      expect(frames[0].getScore()).toEqual(6);
-      expect(frames[0].getStatus()).toEqual('completed');
-      expect(frames[1].getRolls()).toEqual([]);
-      expect(frames[1].getStatus()).toEqual('active');
+      const frames = game.frames;
+      expect(frames[0].score).toEqual(6);
+      expect(frames[0].status).toEqual('completed');
+      expect(frames[1].rolls).toEqual([]);
+      expect(frames[1].status).toEqual('active');
     });
 
     it('first frame is a strike', () => {
       game.addRoll(10);
       
-      const frames = game.getFrames();
-      expect(frames[0].getScore()).toEqual(10);
-      expect(frames[0].getStatus()).toEqual('strike');
-      expect(frames[1].getRolls()).toEqual([]);
-      expect(frames[1].getStatus()).toEqual('active');
+      const frames = game.frames;
+      expect(frames[0].score).toEqual(10);
+      expect(frames[0].status).toEqual('strike');
+      expect(frames[1].rolls).toEqual([]);
+      expect(frames[1].status).toEqual('active');
     });
 
     it('first frame is a spare', () => {
       game.addRoll(0);
       game.addRoll(10);
       
-      const frames = game.getFrames();
-      expect(frames[0].getScore()).toEqual(10);
-      expect(frames[0].getStatus()).toEqual('spare');
-      expect(frames[1].getRolls()).toEqual([]);
-      expect(frames[1].getStatus()).toEqual('active');
+      const frames = game.frames;
+      expect(frames[0].score).toEqual(10);
+      expect(frames[0].status).toEqual('spare');
+      expect(frames[1].rolls).toEqual([]);
+      expect(frames[1].status).toEqual('active');
     });
   });
 
@@ -54,11 +54,11 @@ describe('Game integration', () => {
         game.addRoll(4);
       }
 
-      const frames = game.getFrames();
-      expect(frames[0].getStatus()).toEqual('completed');
-      expect(frames[1].getStatus()).toEqual('completed');
-      expect(frames[2].getRolls()).toEqual([4]);
-      expect(frames[2].getStatus()).toEqual('active');
+      const frames = game.frames;
+      expect(frames[0].status).toEqual('completed');
+      expect(frames[1].status).toEqual('completed');
+      expect(frames[2].rolls).toEqual([4]);
+      expect(frames[2].status).toEqual('active');
     });
   });
 
@@ -68,9 +68,9 @@ describe('Game integration', () => {
         game.addRoll(0);
       }
 
-      const frames = game.getFrames();
-      expect(frames.every(frame => frame.getScore() === 0)).toBe(true);
-      expect(frames.every(frame => frame.getStatus() === 'completed')).toBe(true);
+      const frames = game.frames;
+      expect(frames.every(frame => frame.score === 0)).toBe(true);
+      expect(frames.every(frame => frame.status === 'completed')).toBe(true);
     });
 
     it('full game with rolls of 4', () => {
@@ -78,9 +78,9 @@ describe('Game integration', () => {
         game.addRoll(4);
       }
 
-      const frames = game.getFrames();
-      expect(frames.every(frame => frame.getScore() === 8)).toBe(true);
-      expect(frames.every(frame => frame.getStatus() === 'completed')).toBe(true);
+      const frames = game.frames;
+      expect(frames.every(frame => frame.score === 8)).toBe(true);
+      expect(frames.every(frame => frame.status === 'completed')).toBe(true);
     });
 
     it('10 strikes (without frame 10)', () => {
@@ -88,17 +88,17 @@ describe('Game integration', () => {
         game.addRoll(10);
       }
 
-      const frames = game.getFrames();
+      const frames = game.frames;
       for (let i = 0; i < 8; i++) {
-        expect(frames[i].getScore()).toBe(30);
-        expect(frames[i].getStatus()).toBe('completed')
+        expect(frames[i].score).toBe(30);
+        expect(frames[i].status).toBe('completed')
       }
 
-      expect(frames[8].getScore()).toBe(20);
-      expect(frames[8].getStatus()).toBe('strike')
+      expect(frames[8].score).toBe(20);
+      expect(frames[8].status).toBe('strike')
 
-      expect(frames[9].getScore()).toBe(10);
-      expect(frames[9].getStatus()).toBe('strike')
+      expect(frames[9].score).toBe(10);
+      expect(frames[9].status).toBe('strike')
     });
 
     it('10 [9, 1] spares (without frame 10)', () => {
@@ -107,13 +107,13 @@ describe('Game integration', () => {
         game.addRoll(1);
       }
 
-      const frames = game.getFrames();
+      const frames = game.frames;
       for (let i = 0; i < 9; i++) {
-        expect(frames[i].getScore()).toBe(19);
-        expect(frames[i].getStatus()).toBe('completed')
+        expect(frames[i].score).toBe(19);
+        expect(frames[i].status).toBe('completed')
       }
 
-      expect(frames[9].getScore()).toBe(10);
+      expect(frames[9].score).toBe(10);
     });
 
     it('throws error when trying to add a new roll', () => {
@@ -133,10 +133,10 @@ describe('Game integration', () => {
       game.addRoll(6);
       game.addRoll(4);
 
-      const frames = game.getFrames();
-      expect(frames[0].getRolls()).toEqual([10]);
-      expect(frames[0].getScore()).toEqual(16);
-      expect(frames[0].getStatus()).toEqual('completed');
+      const frames = game.frames;
+      expect(frames[0].rolls).toEqual([10]);
+      expect(frames[0].score).toEqual(16);
+      expect(frames[0].status).toEqual('completed');
     });
 
     it('two strikes and a roll', () => {
@@ -144,17 +144,17 @@ describe('Game integration', () => {
       game.addRoll(10);
       game.addRoll(4);
 
-      const frames = game.getFrames();
-      expect(frames[0].getStatus()).toEqual('completed');
-      expect(frames[0].getRolls()).toEqual([10]);
-      expect(frames[0].getScore()).toEqual(24);
+      const frames = game.frames;
+      expect(frames[0].status).toEqual('completed');
+      expect(frames[0].rolls).toEqual([10]);
+      expect(frames[0].score).toEqual(24);
 
-      expect(frames[1].getStatus()).toEqual('strike');
-      expect(frames[1].getRolls()).toEqual([10]);
-      expect(frames[1].getScore()).toEqual(14);
+      expect(frames[1].status).toEqual('strike');
+      expect(frames[1].rolls).toEqual([10]);
+      expect(frames[1].score).toEqual(14);
 
-      expect(frames[2].getRolls()).toEqual([4]);
-      expect(frames[2].getStatus()).toEqual('active');
+      expect(frames[2].rolls).toEqual([4]);
+      expect(frames[2].status).toEqual('active');
     });
   });
 
@@ -164,12 +164,12 @@ describe('Game integration', () => {
       game.addRoll(1);
 
       game.addRoll(6);
-      expect(game.getFrames()[0].getRolls()).toEqual([9, 1]);
-      expect(game.getFrames()[0].getScore()).toEqual(16);
-      expect(game.getFrames()[0].getStatus()).toEqual('completed');
+      expect(game.frames[0].rolls).toEqual([9, 1]);
+      expect(game.frames[0].score).toEqual(16);
+      expect(game.frames[0].status).toEqual('completed');
 
       game.addRoll(4);
-      expect(game.getFrames()[0].getScore()).toEqual(16);
+      expect(game.frames[0].score).toEqual(16);
     });
   });
 });


### PR DESCRIPTION
We have remove private instance variables like `#rolls` in favour of using the default public instance variables.

We have done this in order to better allow for inheritance calls when creating the `Frame10` class, since private variables are no longer accessible to child classes.

We want to leave this branch open after merging with main in order to validate whether or not private _methods_ such as `#validateRoll` also need to be refactored for use in inheritance.