### PR TITLE
Removes private methods from Frame

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -8,18 +8,18 @@ class Frame {
   }
 
   addRoll(roll) {
-    this.#validateRoll(roll);
+    this.validateRoll(roll);
     if (this.status !== 'active') throw 'Cannot add rolls to this frame';
     if (this.score + roll > 10) throw 'Rolls cannot add up to more than 10';
 
     this.score += roll;
     this.rolls.push(roll);
     
-    this.#updateStatus();
+    this.updateStatus();
   }
 
   addBonus(roll) {
-    this.#validateRoll(roll);
+    this.validateRoll(roll);
     if (this.bonusesLeft > 0) {
       this.score += roll;
       this.bonusesLeft--;
@@ -42,7 +42,7 @@ class Frame {
     }
   }
 
-  #updateStatus() {
+  updateStatus() {
     if (this.score === 10 && this.rolls.length === 1) {
       this.status = 'strike';
       this.bonusesLeft = 2;
@@ -54,7 +54,7 @@ class Frame {
     }
   }
 
-  #validateRoll(roll) {
+  validateRoll(roll) {
     if (roll < 0 || roll > 10) throw 'A roll must be between 0 and 10';
     if (!Number.isInteger(roll)) throw 'A roll must be an integer';
   }


### PR DESCRIPTION
We also remove private methods from the `Frame` class in order to amend them in our inherited `Frame10` class.